### PR TITLE
props に対応した

### DIFF
--- a/app/javascript/editor.vue
+++ b/app/javascript/editor.vue
@@ -80,7 +80,15 @@ export default {
     // Vue でマウント状態のガジェットを
     // カスタムタグの状態に戻す
     _revertGadgets: function (text) {
-      return revertGadgets(text)
+      // props を取り出す
+      const attrs = {}
+      const refs = this.gadgetVm.$refs
+      for (let ref in refs) {
+        const component = refs[ref]
+        attrs[ref] = component.$props
+      }
+
+      return revertGadgets(text, attrs)
     }
   }
 }

--- a/app/javascript/editor_gadgets.js
+++ b/app/javascript/editor_gadgets.js
@@ -6,7 +6,15 @@ import Gadgets from 'gadgets/gadgets'
 function addMarker() {
   const mixin = {
     mounted: function () {
+      // タグの名前
       this.$el.setAttribute('data-g-name', this.$options._componentTag)
+
+      // タグの識別子
+      // ref で props を取る
+      const ref = findSelfRef(this)
+      if (ref) {
+        this.$el.setAttribute('data-g-ref', ref)
+      }
 
       // 中身は編集させない
       this.$el.setAttribute('contenteditable', false)
@@ -27,6 +35,19 @@ function addMarker() {
   }
 
   Gadgets.components = processed
+}
+
+// component の親から自身への ref を取得する
+function findSelfRef(component) {
+  const refs = component.$parent.$refs
+
+  for (let ref in refs) {
+    if (refs[ref] == component) {
+      return ref
+    }
+  }
+
+  return null
 }
 
 addMarker()

--- a/app/javascript/editor_gadgets.js
+++ b/app/javascript/editor_gadgets.js
@@ -7,6 +7,9 @@ function addMarker() {
   const mixin = {
     mounted: function () {
       this.$el.setAttribute('data-g-name', this.$options._componentTag)
+
+      // 中身は編集させない
+      this.$el.setAttribute('contenteditable', false)
     }
   }
 

--- a/app/javascript/editor_palette.vue
+++ b/app/javascript/editor_palette.vue
@@ -18,20 +18,26 @@ export default {
     },
 
     myButton: function () {
-      window.getSelection().getRangeAt(0).insertNode(
-        document.createElement('my-button')
-      )
-      this.$emit('addCustomTag')
+      this._insertGadget('my-button', [
+        {
+          name: 'text',
+          value: 'マイボタン'
+        }
+      ])
     },
 
     countryList: function () {
       this._insertGadget('country-list')
     },
 
-    _insertGadget: function (name) {
-      window.getSelection().getRangeAt(0).insertNode(
-        document.createElement(name)
-      )
+    _insertGadget: function (name, attrs=[]) {
+      const element = document.createElement(name)
+
+      for (const attr of attrs) {
+        element.setAttribute(attr['name'], attr['value'])
+      }
+
+      window.getSelection().getRangeAt(0).insertNode(element)
       this.$emit('addCustomTag')
     }
   }

--- a/app/javascript/editor_palette.vue
+++ b/app/javascript/editor_palette.vue
@@ -11,6 +11,25 @@
 
 <script>
 
+function _getRandomInt(min, max) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min)) + min;
+}
+
+function _getRandomString() {
+  const seed = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  const stringLength = 6
+
+  let string = ''
+  for (let i=0; i < stringLength; i++) {
+    const idx = _getRandomInt(0, seed.length)
+    string += seed[idx]
+  }
+
+  return string
+}
+
 export default {
   methods: {
     save: function () {
@@ -37,6 +56,10 @@ export default {
       for (const attr of attrs) {
         element.setAttribute(attr['name'], attr['value'])
       }
+
+      // set ref
+      // props を復元するときに使う
+      element.setAttribute('ref', _getRandomString())
 
       window.getSelection().getRangeAt(0).insertNode(element)
       this.$emit('addCustomTag')

--- a/app/javascript/editor_palette.vue
+++ b/app/javascript/editor_palette.vue
@@ -33,6 +33,7 @@ export default {
     _insertGadget: function (name, attrs=[]) {
       const element = document.createElement(name)
 
+      // アトリビュートを設定
       for (const attr of attrs) {
         element.setAttribute(attr['name'], attr['value'])
       }

--- a/app/javascript/gadgets/my_button.vue
+++ b/app/javascript/gadgets/my_button.vue
@@ -1,8 +1,20 @@
 <template>
   <div>
-    <a href="/">TOPへ</a>
+    <a href="/">{{ text }}</a>
   </div>
 </template>
+
+<script>
+
+export default {
+  props: {
+    text: {
+      default: 'TOPへ'
+    }
+  }
+}
+
+</script>
 
 <style scoped>
 a {

--- a/app/javascript/revert_gadgets.js
+++ b/app/javascript/revert_gadgets.js
@@ -11,9 +11,9 @@ export default function (innerHTML) {
   // コンポーネントを消して
   // カスタムタグを入れる
   for (let gadget of gadgets) {
-    const component = document.createElement(
-      gadget.getAttribute('data-g-name')
-    )
+    // カスタムタグを作成
+    const tagName = gadget.getAttribute('data-g-name')
+    const component = document.createElement(tagName)
     gadget.parentNode.insertBefore(component, gadget)
     gadget.parentNode.removeChild(gadget)
   }

--- a/app/javascript/revert_gadgets.js
+++ b/app/javascript/revert_gadgets.js
@@ -1,6 +1,11 @@
 // Vue がマウントした HTML を
 // カスタムタグに戻す
-export default function (innerHTML) {
+//
+// attrshash = {
+//   data-g-ref: {text: 'マイボタン' ...},
+//   ...
+// }
+export default function (innerHTML, attrsHash) {
   // DOM 操作をしたい
   const tmp = document.createElement('div')
   tmp.innerHTML = innerHTML
@@ -14,6 +19,16 @@ export default function (innerHTML) {
     // カスタムタグを作成
     const tagName = gadget.getAttribute('data-g-name')
     const component = document.createElement(tagName)
+
+    // attribute(props) を戻す
+    const ref = gadget.getAttribute('data-g-ref')
+    const attrHash = attrsHash[ref]
+    if (attrHash) {
+      for (let attr in attrHash) {
+        component.setAttribute(attr, attrHash[attr])
+      }
+    }
+
     gadget.parentNode.insertBefore(component, gadget)
     gadget.parentNode.removeChild(gadget)
   }


### PR DESCRIPTION
## やったこと
- props 復元できるようにしました
- ガジェット内を編集できないようにした


## キャプチャ

「マイボタン」はカスタムタグに対して props として渡しています

| before | after |
| ------  | ----- |
| ![before](https://user-images.githubusercontent.com/1921593/39106071-4b5ff760-46f4-11e8-9413-1693a840cca5.gif) | ![after](https://user-images.githubusercontent.com/1921593/39106023-0727016a-46f4-11e8-9375-00eb5f85e5f3.gif) |

before では、保存する際に props の情報が欠損していました
今回の対応で、 props を attribute として復元するようにしました
`<my-button text="マイボタン"></my-button>` と保存される