### PR TITLE
エディタで無視する

### DIFF
--- a/app/javascript/packs/editable.js
+++ b/app/javascript/packs/editable.js
@@ -5,6 +5,9 @@ import Gadgets from '@/gadgets/gadgets'
 document.addEventListener('DOMContentLoaded', () => {
   const el = '#editable-content'
 
+  Vue.config.ignoredElements
+    = Object.keys(Gadgets.components).map(key => key.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase())
+
   new Vue({
     el: '#editable-content',
     components: {


### PR DESCRIPTION
エディタ自体の  Vue では Gadget のカスタムタグを無視する
refs 
- https://jp.vuejs.org/v2/api/index.html#ignoredElements
- https://gist.github.com/nblackburn/875e6ff75bc8ce171c758bf75f304707